### PR TITLE
Add manual fund monitoring workflow

### DIFF
--- a/.github/workflows/daily-check.yml
+++ b/.github/workflows/daily-check.yml
@@ -16,11 +16,12 @@ jobs:
       - name: Run AI checks
         run: |
           npm ci
-          npm run check        # <- scrapes pages, audits a11y/compliance/etc.
+          npm run fund-check
 
       - name: Push results to BigQuery
         env:
           BQ_KEY_JSON: ${{ secrets.GCP_KEY }}
+          BQ_TABLE: ${{ secrets.BQ_TABLE || 'fund_monitor.issues' }}
         run: python scripts/insert_results.py
 
   lighthouse:

--- a/.github/workflows/manual-fund-check.yml
+++ b/.github/workflows/manual-fund-check.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Install deps & run checks
         run: |
           npm ci
-          npm run test
-            --urls ${{ inputs.url_file }}
+          npm run fund-check -- --urls ${{ inputs.url_file }}
 
       - name: Push results to BigQuery
         env:
           BQ_KEY_JSON: ${{ secrets.GCP_KEY }}
+          BQ_TABLE: ${{ secrets.BQ_TABLE || 'fund_monitor.issues' }}
         run: python scripts/insert_results.py
 
 # ─────────────────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "run-server": "node lib/browserServer.js",
     "check": "npm run test",
     "clean": "rm -rf lib",
-    "npm-publish": "npm run clean && npm run build && npm run test && npm publish"
+    "npm-publish": "npm run clean && npm run build && npm run test && npm publish",
+    "fund-check": "node scripts/check_funds.mjs"
   },
   "exports": {
     "./package.json": "./package.json",
@@ -42,7 +43,8 @@
     "debug": "^4.4.1",
     "mime": "^4.0.7",
     "playwright": "1.53.0",
-    "zod-to-json-schema": "^3.24.4"
+    "zod-to-json-schema": "^3.24.4",
+    "csv-parse": "^5.5.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/scripts/check_funds.mjs
+++ b/scripts/check_funds.mjs
@@ -1,0 +1,46 @@
+import { chromium } from 'playwright';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import csv from 'csv-parse/lib/sync';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function readCsv(file) {
+  const data = await fs.readFile(file, 'utf8');
+  return csv(data, { columns: false, skip_empty_lines: true }).map(row => row[0]);
+}
+
+async function run(urlsPath) {
+  const urls = await readCsv(urlsPath);
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const results = [];
+
+  for (const url of urls) {
+    const entry = { url, issues: [] };
+    try {
+      await page.goto(url, { waitUntil: 'domcontentloaded' });
+      const title = await page.title();
+      if (!title) entry.issues.push('Missing page title');
+      const text = await page.textContent('body');
+      if (text && !/important information|disclaimer/i.test(text)) {
+        entry.issues.push('Missing compliance disclaimer');
+      }
+    } catch (e) {
+      entry.issues.push(`Navigation error: ${e.message}`);
+    }
+    results.push(entry);
+  }
+
+  await browser.close();
+  await fs.writeFile(path.join(__dirname, 'results.json'), JSON.stringify(results, null, 2));
+}
+
+const urlsArgIndex = process.argv.indexOf('--urls');
+const urlsFile = urlsArgIndex !== -1 ? process.argv[urlsArgIndex + 1] : 'config/urls.csv';
+run(urlsFile).catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/insert_results.py
+++ b/scripts/insert_results.py
@@ -1,0 +1,36 @@
+import json
+import os
+from datetime import datetime
+from google.cloud import bigquery
+
+# Get BigQuery credentials from environment variable
+key_json = os.environ.get('BQ_KEY_JSON')
+if not key_json:
+    raise SystemExit('BQ_KEY_JSON env var is required')
+
+credentials = bigquery.Client.from_service_account_info(json.loads(key_json))
+client = credentials
+
+def load_results(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+results = load_results(os.path.join(os.path.dirname(__file__), 'results.json'))
+
+rows = []
+for entry in results:
+    for issue in entry.get('issues', []):
+        rows.append({
+            'timestamp': datetime.utcnow().isoformat(),
+            'url': entry['url'],
+            'issue': issue,
+        })
+
+if rows:
+    table_id = os.environ.get('BQ_TABLE', 'fund_monitor.issues')
+    errors = client.insert_rows_json(table_id, rows)
+    if errors:
+        raise RuntimeError(f'Failed to insert rows: {errors}')
+    print(f'Inserted {len(rows)} rows into {table_id}')
+else:
+    print('No issues found; nothing to insert')

--- a/workflows/daily-check.yml
+++ b/workflows/daily-check.yml
@@ -16,11 +16,12 @@ jobs:
       - name: Run AI checks
         run: |
           npm ci
-          npm run check        # <- scrapes pages, audits a11y/compliance/etc.
+          npm run fund-check
 
       - name: Push results to BigQuery
         env:
           BQ_KEY_JSON: ${{ secrets.GCP_KEY }}
+          BQ_TABLE: ${{ secrets.BQ_TABLE || 'fund_monitor.issues' }}
         run: python scripts/insert_results.py
 
   lighthouse:


### PR DESCRIPTION
## Summary
- create simple fund-check Node script
- add BigQuery insertion script
- update workflows to run the new scripts
- allow manual workflow trigger

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f15f17b80832baa4ebbe99316c2e1