### PR TITLE
Simplify manual fund check workflow

### DIFF
--- a/.github/workflows/manual-fund-check.yml
+++ b/.github/workflows/manual-fund-check.yml
@@ -1,21 +1,10 @@
-name: Manual Fund Page Check   # appears in the Actions sidebar
+name: Manual Fund Compliance Check   # appears in the Actions sidebar
 
 # ─────────────────────────────────────────────────────────────
 # Trigger: manual only
 # ─────────────────────────────────────────────────────────────
 on:
-  workflow_dispatch:           # adds the “Run workflow” button
-    inputs:
-      url_file:
-        description: "CSV file path with URLs (default: config/urls.csv)"
-        required: false
-        default: "config/urls.csv"
-      run_lighthouse:
-        description: "Run Lighthouse performance job too?"
-        required: false
-        default: "true"
-        type: choice
-        options: ["true", "false"]
+  workflow_dispatch:
 
 # ─────────────────────────────────────────────────────────────
 # 1st job – main AI/MCP checks
@@ -33,24 +22,10 @@ jobs:
         run: |
           npm ci
           npm run test
-            --urls ${{ inputs.url_file }}
 
       - name: Push results to BigQuery
         env:
           BQ_KEY_JSON: ${{ secrets.GCP_KEY }}
         run: python scripts/insert_results.py
 
-# ─────────────────────────────────────────────────────────────
-# 2nd job – Lighthouse (optional)
-# ─────────────────────────────────────────────────────────────
-  lighthouse:
-    needs: run-monitor
-    if: ${{ inputs.run_lighthouse == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
 
-      - uses: treosh/lighthouse-ci-action@v10
-        with:
-          urls: ${{ inputs.url_file }}
-          budgetPath: budgets/perf-budget.json


### PR DESCRIPTION
## Summary
- restore BigQuery upload in manual fund check workflow
- keep Lighthouse step removed so the workflow runs faster
- remove unused URL argument to prevent runtime error

## Testing
- `npm ci`
- `npx playwright install --with-deps chromium`


------
https://chatgpt.com/codex/tasks/task_b_684fc5115978832b8fb3f21ace4a826b